### PR TITLE
nvim lua設定のバグ4件を修正

### DIFF
--- a/modules/editor/neovim/nvim/lua/plugins/cmp.lua
+++ b/modules/editor/neovim/nvim/lua/plugins/cmp.lua
@@ -26,6 +26,24 @@ return {
           ["<C-Space>"] = cmp.mapping.complete(),
           ["<C-@>"] = cmp.mapping.complete(),
           ["<CR>"] = cmp.mapping.confirm({ select = true }),
+          ["<Tab>"] = cmp.mapping(function(fallback)
+            if cmp.visible() then
+              cmp.select_next_item()
+            elseif luasnip.expand_or_jumpable() then
+              luasnip.expand_or_jump()
+            else
+              fallback()
+            end
+          end, { "i", "s" }),
+          ["<S-Tab>"] = cmp.mapping(function(fallback)
+            if cmp.visible() then
+              cmp.select_prev_item()
+            elseif luasnip.jumpable(-1) then
+              luasnip.jump(-1)
+            else
+              fallback()
+            end
+          end, { "i", "s" }),
         }),
         sources = cmp.config.sources({
           { name = "nvim_lsp" },

--- a/modules/editor/neovim/nvim/lua/plugins/formatter.lua
+++ b/modules/editor/neovim/nvim/lua/plugins/formatter.lua
@@ -22,7 +22,7 @@ return {
       conform.setup({
         formatters_by_ft = {
           lua = { "stylua" },
-          nix = { "nixpkgs-fmt" },
+          nix = { "nixpkgs_fmt" },
           rust = { "rustfmt" },
           go = { "gofmt" },
           javascript = { "prettier" },

--- a/modules/editor/neovim/nvim/lua/plugins/lsp/servers/verilog.lua
+++ b/modules/editor/neovim/nvim/lua/plugins/lsp/servers/verilog.lua
@@ -14,7 +14,6 @@ return function(capabilities, on_attach)
     on_attach = on_attach,
     filetypes = { "verilog", "systemverilog" },
     capabilities = capabilities,
-    root_dir = vim.fs.root(0, { ".git" }),
     settings = {
       systemverilog = {
         -- Enable SystemVerilog syntax (always_comb, etc.)
@@ -32,7 +31,10 @@ return function(capabilities, on_attach)
     callback = function(event)
       local svls_config = vim.lsp.config["svls"]
       if svls_config then
-        vim.lsp.start(svls_config, { bufnr = event.buf })
+        local config = vim.tbl_extend("force", svls_config, {
+          root_dir = vim.fs.root(event.buf, { ".git" }),
+        })
+        vim.lsp.start(config, { bufnr = event.buf })
       end
     end,
   })

--- a/modules/editor/neovim/nvim/lua/plugins/lsp/servers/web.lua
+++ b/modules/editor/neovim/nvim/lua/plugins/lsp/servers/web.lua
@@ -10,11 +10,30 @@ return function(capabilities, on_attach)
 
   vim.api.nvim_create_autocmd("BufWritePre", {
     pattern = { "*.ts", "*.tsx", "*.js", "*.jsx" },
-    callback = function()
-      vim.lsp.buf.code_action({
-        context = { only = { "source.fixAll.eslint" } },
-        apply = true,
-      })
+    callback = function(args)
+      local clients = vim.lsp.get_clients({ bufnr = args.buf, name = "eslint" })
+      if #clients == 0 then
+        return
+      end
+      local client = clients[1]
+
+      -- code_action() is async, so a fire-and-forget call here can leave the
+      -- fix unapplied by the time BufWritePre returns and the write happens.
+      -- Block synchronously so the fix lands before the file is saved.
+      local params = vim.lsp.util.make_range_params(0, client.offset_encoding)
+      params.context = { only = { "source.fixAll.eslint" }, diagnostics = {} }
+      local result = client:request_sync("textDocument/codeAction", params, 1000, args.buf)
+      if not result or not result.result then
+        return
+      end
+
+      for _, action in ipairs(result.result) do
+        if action.edit then
+          vim.lsp.util.apply_workspace_edit(action.edit, client.offset_encoding)
+        elseif action.command then
+          client:exec_cmd(action.command, { bufnr = args.buf })
+        end
+      end
     end,
   })
 end

--- a/modules/editor/neovim/nvim/lua/plugins/lsp/servers/web.lua
+++ b/modules/editor/neovim/nvim/lua/plugins/lsp/servers/web.lua
@@ -28,9 +28,12 @@ return function(capabilities, on_attach)
       end
 
       for _, action in ipairs(result.result) do
+        -- a CodeAction may carry both an edit and a command; apply the edit
+        -- first, then run the command so neither is silently dropped
         if action.edit then
           vim.lsp.util.apply_workspace_edit(action.edit, client.offset_encoding)
-        elseif action.command then
+        end
+        if action.command then
           client:exec_cmd(action.command, { bufnr = args.buf })
         end
       end


### PR DESCRIPTION
## Summary
- `formatter.lua`: conform.nvimのフォーマッタ登録名を`nixpkgs-fmt`→`nixpkgs_fmt`に修正（nix保存時フォーマットが無効だったバグ）
- `lsp/servers/verilog.lua`: svlsの`root_dir`をsetup時の静的評価からバッファごとの動的解決に修正（複数プロジェクトを跨ぐと最初のrootに固定されるバグ）
- `lsp/servers/web.lua`: eslintの`BufWritePre` fixAllを非同期呼び出しから同期呼び出しに変更（保存前に修正が反映されないレースコンディション）
- `cmp.lua`: LuaSnipのジャンプ・補完選択キーマップ（`<Tab>`/`<S-Tab>`）を追加（未設定だった）

## Test plan
- [x] headless nvim + XDG_CONFIG_HOMEで実際に設定をロードし、main（修正前）と修正branchを比較
- [x] nixpkgs_fmt: conformの`list_formatters_to_run`でmainは未検出・修正branchは`available`を確認
- [x] svls: 2つの独立git projectを開き、mainは同一root_dirのクライアントに固定・修正branchは各projectごとに正しいroot_dirで分離されることを確認
- [x] eslint: 偽のLSPサーバーでcodeActionに応答させ、mainはディスク上のファイルが未修正のまま保存される・修正branchは保存前に修正が適用されることを確認
- [x] cmp: `<Tab>`/`<S-Tab>`がcmpの設定に登録されていることを確認（mainは未登録）

## Note
コードレビューで洗い出した項目のうち、この4件は実際の挙動バグとして修正。LSP起動方式の不統一やneotreeのキーマップ記法差異など、動作に影響しないコンシステンシー面の指摘は今回スコープ外。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Tab and Shift-Tab behavior in completion menus and snippet navigation for a smoother editing experience.
* **Bug Fixes**
  * Updated Nix formatting to use the correct formatter name.
  * Improved Verilog/SystemVerilog language server project detection for more reliable per-file behavior.
  * Made JavaScript/TypeScript save-time lint fixes apply more consistently before files are written.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->