### PR TITLE
claude設定のpermissions allowlistを拡充

### DIFF
--- a/modules/ai/claude/template/settings.json
+++ b/modules/ai/claude/template/settings.json
@@ -3,7 +3,33 @@
     "allow": [
       "Read",
       "WebFetch",
-      "WebSearch"
+      "WebSearch",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(ls:*)",
+      "Bash(pwd)",
+      "Bash(grep:*)",
+      "Bash(rg:*)",
+      "Bash(find:*)",
+      "Bash(which:*)",
+      "Bash(git add:*)",
+      "Bash(git branch:*)",
+      "Bash(git commit:*)",
+      "Bash(mkdir:*)",
+      "Bash(cat:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(curl http://localhost:*)",
+      "Bash(curl http://127.0.0.1:*)"
+    ],
+    "deny": [
+      "Bash(rm -rf:*)",
+      "Bash(git push --force:*)",
+      "Bash(git reset --hard:*)",
+      "Bash(git clean:*)",
+      "Bash(sudo:*)"
     ]
   },
   "hooks": {


### PR DESCRIPTION
## Summary
- 安全で可逆な読み取り系Bash操作（git status/diff/log/show, ls, grep, rg, find, which）と git add/branch/commit, mkdir, cat/head/tail, localhostへのcurlをpermissions.allowに追加
- 破壊的・不可逆な操作（rm -rf, git push --force, git reset --hard, git clean, sudo）をpermissions.denyに追加

## Test plan
- [x] settings.json が有効なJSONであることを確認
- [ ] home-manager switch --flake . で反映確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)