### PR TITLE
nvim lua設定の構造をさらに整理

### DIFF
--- a/modules/editor/neovim/nvim/lua/plugins/cmp.lua
+++ b/modules/editor/neovim/nvim/lua/plugins/cmp.lua
@@ -1,56 +1,54 @@
 return {
-  {
-    "hrsh7th/nvim-cmp",
-    dependencies = {
-      "hrsh7th/cmp-nvim-lsp",
-      "L3MON4D3/LuaSnip",
-    },
-    config = function()
-      local cmp = require("cmp")
-      local luasnip = require("luasnip")
-      cmp.setup({
-        snippet = {
-          expand = function(args)
-            luasnip.lsp_expand(args.body)
-          end,
-        },
-        completion = {
-          autocomplete = { cmp.TriggerEvent.InsertEnter, cmp.TriggerEvent.TextChanged },
-        },
-        performance = {
-          debounce = 60,
-          throttle = 30,
-          fetching_timeout = 500,
-        },
-        mapping = cmp.mapping.preset.insert({
-          ["<C-Space>"] = cmp.mapping.complete(),
-          ["<C-@>"] = cmp.mapping.complete(),
-          ["<CR>"] = cmp.mapping.confirm({ select = true }),
-          ["<Tab>"] = cmp.mapping(function(fallback)
-            if cmp.visible() then
-              cmp.select_next_item()
-            elseif luasnip.expand_or_jumpable() then
-              luasnip.expand_or_jump()
-            else
-              fallback()
-            end
-          end, { "i", "s" }),
-          ["<S-Tab>"] = cmp.mapping(function(fallback)
-            if cmp.visible() then
-              cmp.select_prev_item()
-            elseif luasnip.jumpable(-1) then
-              luasnip.jump(-1)
-            else
-              fallback()
-            end
-          end, { "i", "s" }),
-        }),
-        sources = cmp.config.sources({
-          { name = "nvim_lsp" },
-        }, {
-          { name = "buffer" },
-        }),
-      })
-    end,
+  "hrsh7th/nvim-cmp",
+  dependencies = {
+    "hrsh7th/cmp-nvim-lsp",
+    "L3MON4D3/LuaSnip",
   },
+  config = function()
+    local cmp = require("cmp")
+    local luasnip = require("luasnip")
+    cmp.setup({
+      snippet = {
+        expand = function(args)
+          luasnip.lsp_expand(args.body)
+        end,
+      },
+      completion = {
+        autocomplete = { cmp.TriggerEvent.InsertEnter, cmp.TriggerEvent.TextChanged },
+      },
+      performance = {
+        debounce = 60,
+        throttle = 30,
+        fetching_timeout = 500,
+      },
+      mapping = cmp.mapping.preset.insert({
+        ["<C-Space>"] = cmp.mapping.complete(),
+        ["<C-@>"] = cmp.mapping.complete(),
+        ["<CR>"] = cmp.mapping.confirm({ select = true }),
+        ["<Tab>"] = cmp.mapping(function(fallback)
+          if cmp.visible() then
+            cmp.select_next_item()
+          elseif luasnip.expand_or_jumpable() then
+            luasnip.expand_or_jump()
+          else
+            fallback()
+          end
+        end, { "i", "s" }),
+        ["<S-Tab>"] = cmp.mapping(function(fallback)
+          if cmp.visible() then
+            cmp.select_prev_item()
+          elseif luasnip.jumpable(-1) then
+            luasnip.jump(-1)
+          else
+            fallback()
+          end
+        end, { "i", "s" }),
+      }),
+      sources = cmp.config.sources({
+        { name = "nvim_lsp" },
+      }, {
+        { name = "buffer" },
+      }),
+    })
+  end,
 }

--- a/modules/editor/neovim/nvim/lua/plugins/formatter.lua
+++ b/modules/editor/neovim/nvim/lua/plugins/formatter.lua
@@ -1,49 +1,47 @@
 return {
-  {
-    "stevearc/conform.nvim",
-    event = { "BufReadPre", "BufNewFile" },
-    keys = {
-      {
-        "<leader>f",
-        function()
-          require("conform").format({
-            lsp_fallback = true,
-            async = false,
-            timeout_ms = 1000,
-          })
-        end,
-        mode = { "n", "v" },
-        desc = "Format file or range (in visual mode)",
-      },
-    },
-    config = function()
-      local conform = require("conform")
-
-      conform.setup({
-        formatters_by_ft = {
-          lua = { "stylua" },
-          nix = { "nixpkgs_fmt" },
-          rust = { "rustfmt" },
-          go = { "gofmt" },
-          javascript = { "prettier" },
-          typescript = { "prettier" },
-          json = { "prettier" },
-          yaml = { "prettier" },
-          systemverilog = { "verible_verilog_format" },
-          verilog = { "verible_verilog_format" },
-        },
-        formatters = {
-          verible_verilog_format = {
-            command = "verible-verilog-format",
-            args = { "-" },
-            stdin = true,
-          },
-        },
-        format_on_save = {
-          timeout_ms = 1000,
+  "stevearc/conform.nvim",
+  event = { "BufReadPre", "BufNewFile" },
+  keys = {
+    {
+      "<leader>f",
+      function()
+        require("conform").format({
           lsp_fallback = true,
-        },
-      })
-    end,
+          async = false,
+          timeout_ms = 1000,
+        })
+      end,
+      mode = { "n", "v" },
+      desc = "Format file or range (in visual mode)",
+    },
   },
+  config = function()
+    local conform = require("conform")
+
+    conform.setup({
+      formatters_by_ft = {
+        lua = { "stylua" },
+        nix = { "nixpkgs_fmt" },
+        rust = { "rustfmt" },
+        go = { "gofmt" },
+        javascript = { "prettier" },
+        typescript = { "prettier" },
+        json = { "prettier" },
+        yaml = { "prettier" },
+        systemverilog = { "verible_verilog_format" },
+        verilog = { "verible_verilog_format" },
+      },
+      formatters = {
+        verible_verilog_format = {
+          command = "verible-verilog-format",
+          args = { "-" },
+          stdin = true,
+        },
+      },
+      format_on_save = {
+        timeout_ms = 1000,
+        lsp_fallback = true,
+      },
+    })
+  end,
 }

--- a/modules/editor/neovim/nvim/lua/plugins/lsp/init.lua
+++ b/modules/editor/neovim/nvim/lua/plugins/lsp/init.lua
@@ -1,24 +1,22 @@
 return {
-  {
-    "neovim/nvim-lspconfig",
-    config = function()
-      vim.diagnostic.config({
-        virtual_text = true,
-      })
+  "neovim/nvim-lspconfig",
+  config = function()
+    vim.diagnostic.config({
+      virtual_text = true,
+    })
 
-      local capabilities = require("cmp_nvim_lsp").default_capabilities()
-      local on_attach = function(_, bufnr)
-        local map = function(mode, lhs, rhs)
-          vim.keymap.set(mode, lhs, rhs, { buffer = bufnr, noremap = true, silent = true })
-        end
-        map("n", "gd", vim.lsp.buf.definition)
-        map("n", "K", vim.lsp.buf.hover)
+    local capabilities = require("cmp_nvim_lsp").default_capabilities()
+    local on_attach = function(_, bufnr)
+      local map = function(mode, lhs, rhs)
+        vim.keymap.set(mode, lhs, rhs, { buffer = bufnr, noremap = true, silent = true })
       end
+      map("n", "gd", vim.lsp.buf.definition)
+      map("n", "K", vim.lsp.buf.hover)
+    end
 
-      require("plugins.lsp.servers.rust")(capabilities, on_attach)
-      require("plugins.lsp.servers.go")(capabilities, on_attach)
-      require("plugins.lsp.servers.verilog")(capabilities, on_attach)
-      require("plugins.lsp.servers.web")(capabilities, on_attach)
-    end,
-  },
+    require("plugins.lsp.servers.rust")(capabilities, on_attach)
+    require("plugins.lsp.servers.go")(capabilities, on_attach)
+    require("plugins.lsp.servers.verilog")(capabilities, on_attach)
+    require("plugins.lsp.servers.web")(capabilities, on_attach)
+  end,
 }

--- a/modules/editor/neovim/nvim/lua/plugins/lsp/servers/go.lua
+++ b/modules/editor/neovim/nvim/lua/plugins/lsp/servers/go.lua
@@ -1,10 +1,11 @@
 return function(capabilities, on_attach)
-  local filetypes = { "go", "gomod", "gowork", "gotmpl" }
-
   vim.lsp.config("gopls", {
     on_attach = on_attach,
-    filetypes = filetypes,
+    filetypes = { "go", "gomod", "gowork", "gotmpl" },
     capabilities = capabilities,
+    root_dir = function(bufnr, on_dir)
+      on_dir(vim.fs.root(bufnr, { "go.work", "go.mod", ".git" }))
+    end,
     settings = {
       gopls = {
         analyses = {
@@ -15,13 +16,5 @@ return function(capabilities, on_attach)
     },
   })
 
-  vim.api.nvim_create_autocmd("FileType", {
-    pattern = filetypes,
-    callback = function(event)
-      local config = vim.lsp.config["gopls"]
-      if config then
-        vim.lsp.start(config, { bufnr = event.buf })
-      end
-    end,
-  })
+  vim.lsp.enable("gopls")
 end

--- a/modules/editor/neovim/nvim/lua/plugins/lsp/servers/verilog.lua
+++ b/modules/editor/neovim/nvim/lua/plugins/lsp/servers/verilog.lua
@@ -14,6 +14,9 @@ return function(capabilities, on_attach)
     on_attach = on_attach,
     filetypes = { "verilog", "systemverilog" },
     capabilities = capabilities,
+    root_dir = function(bufnr, on_dir)
+      on_dir(vim.fs.root(bufnr, { ".git" }))
+    end,
     settings = {
       systemverilog = {
         -- Enable SystemVerilog syntax (always_comb, etc.)
@@ -26,16 +29,5 @@ return function(capabilities, on_attach)
     },
   })
 
-  vim.api.nvim_create_autocmd("FileType", {
-    pattern = { "verilog", "systemverilog" },
-    callback = function(event)
-      local svls_config = vim.lsp.config["svls"]
-      if svls_config then
-        local config = vim.tbl_extend("force", svls_config, {
-          root_dir = vim.fs.root(event.buf, { ".git" }),
-        })
-        vim.lsp.start(config, { bufnr = event.buf })
-      end
-    end,
-  })
+  vim.lsp.enable("svls")
 end

--- a/modules/editor/neovim/nvim/lua/plugins/neotree.lua
+++ b/modules/editor/neovim/nvim/lua/plugins/neotree.lua
@@ -1,3 +1,173 @@
+local default_component_configs = {
+  container = {
+    enable_character_fade = true
+  },
+  indent = {
+    indent_size = 2,
+    padding = 1,
+    with_markers = true,
+    indent_marker = "│",
+    last_indent_marker = "└",
+    highlight = "NeoTreeIndentMarker",
+    with_expanders = nil,
+    expander_collapsed = "",
+    expander_expanded = "",
+    expander_highlight = "NeoTreeExpander",
+  },
+  icon = {
+    folder_closed = "",
+    folder_open = "",
+    folder_empty = "ﰊ",
+    default = "*",
+    highlight = "NeoTreeFileIcon"
+  },
+  modified = {
+    symbol = "[+]",
+    highlight = "NeoTreeModified",
+  },
+  name = {
+    trailing_slash = false,
+    use_git_status_colors = true,
+    highlight = "NeoTreeFileName",
+  },
+  git_status = {
+    symbols = {
+      added     = "",
+      modified  = "",
+      deleted   = "✖",
+      renamed   = "",
+      untracked = "",
+      ignored   = "",
+      unstaged  = "",
+      staged    = "",
+      conflict  = "",
+    }
+  },
+}
+
+local window = {
+  position = "left",
+  width = 25,
+  mapping_options = {
+    noremap = true,
+    nowait = true,
+  },
+  mappings = {
+    ["<space>"] = {
+      "toggle_node",
+      nowait = false,
+    },
+    ["<2-LeftMouse>"] = "open",
+    ["<cr>"] = "open",
+    ["<esc>"] = "revert_preview",
+    ["P"] = { "toggle_preview", config = { use_float = true } },
+    ["l"] = "focus_preview",
+    ["S"] = "open_split",
+    ["s"] = "open_vsplit",
+    ["t"] = "open_tabnew",
+    ["w"] = "open_with_window_picker",
+    ["C"] = "close_node",
+    ["z"] = "close_all_nodes",
+    ["a"] = {
+      "add",
+      config = {
+        show_path = "none"
+      }
+    },
+    ["A"] = "add_directory",
+    ["d"] = "delete",
+    ["r"] = "rename",
+    ["y"] = "copy_to_clipboard",
+    ["x"] = "cut_to_clipboard",
+    ["p"] = "paste_from_clipboard",
+    ["c"] = "copy",
+    ["m"] = "move",
+    ["q"] = "close_window",
+    ["R"] = "refresh",
+    ["?"] = "show_help",
+    ["<"] = "prev_source",
+    [">"] = "next_source",
+  }
+}
+
+local filesystem = {
+  filtered_items = {
+    visible = false,
+    hide_dotfiles = true,
+    hide_gitignored = true,
+    hide_hidden = true,
+    hide_by_name = {
+      --"node_modules"
+    },
+    hide_by_pattern = {
+      --"*.meta",
+      --"*/src/*/tsconfig.json",
+    },
+    always_show = {
+      --".gitignored",
+    },
+    never_show = {
+      --".DS_Store",
+      --"thumbs.db"
+    },
+    never_show_by_pattern = {
+      --".null-ls_*",
+    },
+  },
+  follow_current_file = {
+    enabled = false,
+    leave_dirs_open = false,
+  },
+  group_empty_dirs = false,
+  hijack_netrw_behavior = "open_default",
+  use_libuv_file_watcher = false,
+  window = {
+    mappings = {
+      ["<bs>"] = "navigate_up",
+      ["."] = "set_root",
+      ["H"] = "toggle_hidden",
+      ["/"] = "fuzzy_finder",
+      ["D"] = "fuzzy_finder_directory",
+      ["#"] = "fuzzy_sorter",
+      ["f"] = "filter_on_submit",
+      ["<c-x>"] = "clear_filter",
+      ["[g"] = "prev_git_modified",
+      ["]g"] = "next_git_modified",
+    }
+  }
+}
+
+local buffers = {
+  follow_current_file = {
+    enabled = true,
+    leave_dirs_open = false,
+  },
+  group_empty_dirs = true,
+  show_unloaded = true,
+  window = {
+    mappings = {
+      ["bd"] = "buffer_delete",
+      ["<bs>"] = "navigate_up",
+      ["."] = "set_root",
+    }
+  },
+}
+
+local git_status = {
+  window = {
+    position = "float",
+    mappings = {
+      ["A"]  = "git_add_all",
+      ["gu"] = "git_unstage_file",
+      ["ga"] = "git_add_file",
+      ["gr"] = "git_revert_file",
+      ["gc"] = "git_commit",
+      ["gp"] = "git_push",
+      ["gg"] = "git_commit_and_push",
+    }
+  }
+}
+
 return {
   "nvim-neo-tree/neo-tree.nvim",
   branch = "v3.x",
@@ -16,172 +186,12 @@ return {
       popup_border_style = "rounded",
       enable_git_status = true,
       enable_diagnostics = true,
-      default_component_configs = {
-        container = {
-          enable_character_fade = true
-        },
-        indent = {
-          indent_size = 2,
-          padding = 1,
-          with_markers = true,
-          indent_marker = "│",
-          last_indent_marker = "└",
-          highlight = "NeoTreeIndentMarker",
-          with_expanders = nil,
-          expander_collapsed = "",
-          expander_expanded = "",
-          expander_highlight = "NeoTreeExpander",
-        },
-        icon = {
-          folder_closed = "",
-          folder_open = "",
-          folder_empty = "ﰊ",
-          default = "*",
-          highlight = "NeoTreeFileIcon"
-        },
-        modified = {
-          symbol = "[+]",
-          highlight = "NeoTreeModified",
-        },
-        name = {
-          trailing_slash = false,
-          use_git_status_colors = true,
-          highlight = "NeoTreeFileName",
-        },
-        git_status = {
-          symbols = {
-            added     = "",
-            modified  = "",
-            deleted   = "✖",
-            renamed   = "",
-            untracked = "",
-            ignored   = "",
-            unstaged  = "",
-            staged    = "",
-            conflict  = "",
-          }
-        },
-      },
-      window = {
-        position = "left",
-        width = 25,
-        mapping_options = {
-          noremap = true,
-          nowait = true,
-        },
-        mappings = {
-          ["<space>"] = {
-            "toggle_node",
-            nowait = false,
-          },
-          ["<2-LeftMouse>"] = "open",
-          ["<cr>"] = "open",
-          ["<esc>"] = "revert_preview",
-          ["P"] = { "toggle_preview", config = { use_float = true } },
-          ["l"] = "focus_preview",
-          ["S"] = "open_split",
-          ["s"] = "open_vsplit",
-          ["t"] = "open_tabnew",
-          ["w"] = "open_with_window_picker",
-          ["C"] = "close_node",
-          ["z"] = "close_all_nodes",
-          ["a"] = {
-            "add",
-            config = {
-              show_path = "none"
-            }
-          },
-          ["A"] = "add_directory",
-          ["d"] = "delete",
-          ["r"] = "rename",
-          ["y"] = "copy_to_clipboard",
-          ["x"] = "cut_to_clipboard",
-          ["p"] = "paste_from_clipboard",
-          ["c"] = "copy",
-          ["m"] = "move",
-          ["q"] = "close_window",
-          ["R"] = "refresh",
-          ["?"] = "show_help",
-          ["<"] = "prev_source",
-          [">"] = "next_source",
-        }
-      },
+      default_component_configs = default_component_configs,
+      window = window,
       nesting_rules = {},
-      filesystem = {
-        filtered_items = {
-          visible = false,
-          hide_dotfiles = true,
-          hide_gitignored = true,
-          hide_hidden = true,
-          hide_by_name = {
-            --"node_modules"
-          },
-          hide_by_pattern = {
-            --"*.meta",
-            --"*/src/*/tsconfig.json",
-          },
-          always_show = {
-            --".gitignored",
-          },
-          never_show = {
-            --".DS_Store",
-            --"thumbs.db"
-          },
-          never_show_by_pattern = {
-            --".null-ls_*",
-          },
-        },
-        follow_current_file = {
-          enabled = false,
-          leave_dirs_open = false,
-        },
-        group_empty_dirs = false,
-        hijack_netrw_behavior = "open_default",
-        use_libuv_file_watcher = false,
-        window = {
-          mappings = {
-            ["<bs>"] = "navigate_up",
-            ["."] = "set_root",
-            ["H"] = "toggle_hidden",
-            ["/"] = "fuzzy_finder",
-            ["D"] = "fuzzy_finder_directory",
-            ["#"] = "fuzzy_sorter",
-            ["f"] = "filter_on_submit",
-            ["<c-x>"] = "clear_filter",
-            ["[g"] = "prev_git_modified",
-            ["]g"] = "next_git_modified",
-          }
-        }
-      },
-      buffers = {
-        follow_current_file = {
-          enabled = true,
-          leave_dirs_open = false,
-        },
-        group_empty_dirs = true,
-        show_unloaded = true,
-        window = {
-          mappings = {
-            ["bd"] = "buffer_delete",
-            ["<bs>"] = "navigate_up",
-            ["."] = "set_root",
-          }
-        },
-      },
-      git_status = {
-        window = {
-          position = "float",
-          mappings = {
-            ["A"]  = "git_add_all",
-            ["gu"] = "git_unstage_file",
-            ["ga"] = "git_add_file",
-            ["gr"] = "git_revert_file",
-            ["gc"] = "git_commit",
-            ["gp"] = "git_push",
-            ["gg"] = "git_commit_and_push",
-          }
-        }
-      }
+      filesystem = filesystem,
+      buffers = buffers,
+      git_status = git_status,
     })
   end
 }

--- a/modules/editor/neovim/nvim/lua/plugins/treesitter.lua
+++ b/modules/editor/neovim/nvim/lua/plugins/treesitter.lua
@@ -1,18 +1,16 @@
 return {
-  {
-    "nvim-treesitter/nvim-treesitter",
-    build = ":TSUpdate",
-    config = function()
-      require("nvim-treesitter.configs").setup({
-        ensure_installed = { "lua", "vim", "vimdoc", "rust", "go", "bash", "nix", "typescript" },
-        auto_install = true,
-        highlight = {
-          enable = true,
-        },
-        indent = {
-          enable = true,
-        },
-      })
-    end,
-  },
+  "nvim-treesitter/nvim-treesitter",
+  build = ":TSUpdate",
+  config = function()
+    require("nvim-treesitter.configs").setup({
+      ensure_installed = { "lua", "vim", "vimdoc", "rust", "go", "bash", "nix", "typescript" },
+      auto_install = true,
+      highlight = {
+        enable = true,
+      },
+      indent = {
+        enable = true,
+      },
+    })
+  end,
 }


### PR DESCRIPTION
## Summary
- `neotree.lua`: 187行の巨大なsetup()オプションを関心事ごとのlocal変数（default_component_configs/window/filesystem/buffers/git_status）に分割
- `cmp.lua`/`formatter.lua`/`treesitter.lua`/`lsp/init.lua`: プラグイン1つだけなのに`return { { ... } }`と余分に配列ラップしていたのを解消し、他ファイルと同じ単一テーブル形式に統一
- `lsp/servers/go.lua`/`verilog.lua`: `vim.lsp.enable()`相当を手動のFileType autocmd + `vim.lsp.start()`で再実装していたのをrust.lua/web.luaと同じ`vim.lsp.enable()`に統一

## Note（重要な副産物）
goplsをenable()化する過程で、nvim-lspconfig組み込みのroot_dirデフォルトが`go env`（goバイナリ）に依存しており、本dotfilesにはgoが導入されていない（`modules/lang/`はgcc/nodejs/python3のみ）ため、`.go`ファイルを開くと未捕捉エラーでフリーズすることが判明（headless nvimで再現）。root_dirを`.git`/`go.mod`マーカーベースの自前関数で明示的に上書きして解消。

## Test plan
- [ ] headless nvim + XDG_CONFIG_HOMEで実際に設定をロードし、各変更前後でsetup()に渡る最終オプション/spec構造が一致することを確認
- [x] svls: 2つの独立git projectで正しくroot_dirが分離されることを確認（PR #58の修正が`vim.lsp.enable()`統一後も維持されていることを確認）
- [x] gopls: goバイナリ不在環境で実際に.goファイルを開き、クラッシュせずattach・`gd`キーマップ登録されることを確認
- [x] 6つのLSPサーバー全てがエラーなくロードされることを確認

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>