### PR TITLE
feat(claude): ponytail pluginを追加

### DIFF
--- a/modules/ai/claude/template/settings.json
+++ b/modules/ai/claude/template/settings.json
@@ -150,7 +150,8 @@
   "enabledPlugins": {
     "ppt-creator@daymade-skills": true,
     "typescript-lsp@claude-plugins-official": true,
-    "draw-io@claude-drawio-skill": true
+    "draw-io@claude-drawio-skill": true,
+    "ponytail@ponytail": true
   },
   "extraKnownMarketplaces": {
     "claude-drawio-skill": {
@@ -163,6 +164,12 @@
       "source": {
         "source": "git",
         "url": "https://github.com/thoo/claude-code-zellij-status.git"
+      }
+    },
+    "ponytail": {
+      "source": {
+        "source": "github",
+        "repo": "DietrichGebert/ponytail"
       }
     }
   },


### PR DESCRIPTION
## Summary
- marketplace `DietrichGebert/ponytail` からponytail pluginを有効化する

## Test plan
- [ ] `home-manager switch --flake .` で settings.json が反映されることを確認
- [ ] Claude Code起動時に ponytail plugin が有効になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled the Ponytail plugin.
  * Added the Ponytail GitHub marketplace as an available plugin source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->